### PR TITLE
Updated compile to implementation and some versions.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
         mavenCentral()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
 apply plugin: 'com.android.application'
@@ -14,7 +15,8 @@ repositories {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '27.0.3'
+    flavorDimensions "default"
 
     defaultConfig {
         minSdkVersion 9
@@ -33,12 +35,12 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:cardview-v7:25.2.0'
-    compile 'com.android.support:recyclerview-v7:25.2.0'
-    compile 'com.android.support:appcompat-v7:25.2.0'
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.google.apis:google-api-services-youtube:v3-rev182-1.22.0'
-    compile 'com.google.http-client:google-http-client-android:1.20.0'
-    compile 'com.google.api-client:google-api-client-android:1.20.0'
-    compile 'com.google.api-client:google-api-client-gson:1.20.0'
+    implementation 'com.android.support:cardview-v7:25.2.0'
+    implementation 'com.android.support:recyclerview-v7:25.2.0'
+    implementation 'com.android.support:appcompat-v7:25.2.0'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'com.google.apis:google-api-services-youtube:v3-rev182-1.22.0'
+    implementation 'com.google.http-client:google-http-client-android:1.20.0'
+    implementation 'com.google.api-client:google-api-client-android:1.20.0'
+    implementation 'com.google.api-client:google-api-client-gson:1.20.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+repositories {
+    google()
+}
+buildscript {
+    repositories {
+        google()
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 04 20:04:39 PST 2017
+#Sun Oct 21 11:32:10 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html